### PR TITLE
Fix locale issues

### DIFF
--- a/lib/google_wallet.dart
+++ b/lib/google_wallet.dart
@@ -52,22 +52,29 @@ enum GoogleWalletButtonStyle {
 
 class GoogleWalletButton extends StatelessWidget {
   static const double _minHeight = 48;
-  static const _defaultLocale = 'en';
-  static const _supportedLocales = ['ar', 'az', 'bg', 'br', 'bs', 'by', 'ca', 'cz', 'de', 'dk', 'en_AU', 'en_CA', 'en_GB', 'en_IN', 'en_SG', 'en_US', 'en_ZA', 'es_419', 'es_ES', 'es_US', 'et', 'fl', 'fp', 'fr_CA', 'fr_FR', 'gr', 'he', 'hr', 'hu', 'hy', 'id', 'is', 'it', 'jp', 'ka', 'kk', 'ky', 'lt', 'lv', 'mk', 'my', 'nl', 'no', 'pl', 'pt', 'ro', 'ru', 'se', 'sk', 'sl', 'sq', 'sr', 'th', 'tr', 'uk', 'uz', 'vi', 'zh_HK', 'zh_TW'];
+  static const _defaultLocaleName = 'en_US';
+  static const _supportedLocaleNames = ['ar', 'az', 'bg', 'br', 'bs', 'by', 'ca', 'cz', 'de', 'dk', 'en_AU', 'en_CA', 'en_GB', 'en_IN', 'en_SG', 'en_US', 'en_ZA', 'es_419', 'es_ES', 'es_US', 'et', 'fl', 'fp', 'fr_CA', 'fr_FR', 'gr', 'he', 'hr', 'hu', 'hy', 'id', 'is', 'it', 'jp', 'ka', 'kk', 'ky', 'lt', 'lv', 'mk', 'my', 'nl', 'no', 'pl', 'pt', 'ro', 'ru', 'se', 'sk', 'sl', 'sq', 'sr', 'th', 'tr', 'uk', 'uz', 'vi', 'zh_HK', 'zh_TW'];
 
   final GoogleWalletButtonStyle style;
   final double height;
   final VoidCallback? onPressed;
+  final Locale? locale;
 
   const GoogleWalletButton({
     Key? key,
     this.style = GoogleWalletButtonStyle.primary,
     this.height = _minHeight,
     this.onPressed,
+    this.locale,
   }) : super(key: key);
 
   String _assetPath(context) {
-    final localeName = _supportedLocales.contains(Platform.localeName) ? Platform.localeName : _defaultLocale;
+    String localeName = _defaultLocaleName;
+    if (locale != null && _supportedLocaleNames.contains(locale.toString())) {
+      localeName = locale.toString();
+    } else if (_supportedLocaleNames.contains(Platform.localeName)) {
+      localeName = Platform.localeName;
+    }
     return 'assets/${localeName}_wallet_button_${style.name}.svg';
   }
 


### PR DESCRIPTION
The following issues were addressed:
- The default locale name for `GoogleWalletButton` was "en". However, "en" is not part of the supported locale names. Instead "en_US" should be used.
- `Platform.localeName` can return locales that only consist of a language code (e.g. "de“) or that consist of a country and language code (e.g. "de_DE"). Therefore I've added an option to specify a custom locale in the constructor of `GoogleWalletButton`.