### PR TITLE
Fix saving json pass

### DIFF
--- a/android/src/main/kotlin/io/flutter/plugins/google_wallet/GoogleWalletPlugin.kt
+++ b/android/src/main/kotlin/io/flutter/plugins/google_wallet/GoogleWalletPlugin.kt
@@ -62,7 +62,7 @@ class GoogleWalletPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, Plugi
     when (call.method) {
       METHOD_IS_AVAILABLE -> checkIsAvailable()
       METHOD_SAVE_PASSES ->
-          walletClient.savePasses(call.argument<String>("passJwt")!!, activity!!, REQUEST_CODE)
+          walletClient.savePasses(call.argument<String>("passJson")!!, activity!!, REQUEST_CODE)
       METHOD_SAVE_PASSES_JWT ->
           walletClient.savePassesJwt(call.argument<String>("passJwt")!!, activity!!, REQUEST_CODE)
       else -> result.notImplemented()


### PR DESCRIPTION
Doing some last-minute implementation of Google Wallet for the Flutter challenge, noticed the following issue:

If we send the pass as a JSON (instead of jwt), the native Android code will try to get `jwt` which will result in null pointer exception.